### PR TITLE
Fixed dynamic form submissions by providing the field type

### DIFF
--- a/packages/frontend/src/components/ui/UiCheckboxField.tsx
+++ b/packages/frontend/src/components/ui/UiCheckboxField.tsx
@@ -1,5 +1,6 @@
 import { For } from "solid-js";
 import { UiInputFieldProps } from "./UiInputField.js";
+import { filterProps } from "@solid-primitives/props";
 
 export interface UiCheckboxFieldProps extends UiInputFieldProps {
   options?: () => { label: string; value: string | number }[];
@@ -10,20 +11,23 @@ export default function UiCheckboxField(props: UiCheckboxFieldProps) {
   const options = () => props.options?.() || [];
   return (
     <>
-      <label class={`block text-sm font-medium text-gray-700 mb-2 ${hasError() ? "text-red-900 " : "text-green-900"}`}>
+      <span class={`block text-sm font-medium text-gray-700 mb-2 ${hasError() ? "text-red-900 " : "text-green-900"}`}>
         {props.label()}
-      </label>
+      </span>
       <div class="space-y-2 max-h-40 overflow-y-auto border border-gray-200 rounded-lg p-3">
         <For each={options()}>
           {option => {
-            const value = !Array.isArray(props.value) ? [props.value] : props.value;
+            const value = () => !Array.isArray(props.value) ? [props.value] : props.value;
+            const filteredProps = filterProps(props, key => !["options", "error", "label"].includes(key));
             return (
               <>
                 <div class="flex items-center space-x-2">
                   <input
-                    {...props}
+                    {...filteredProps}
+                    id={`list-${option.value.toString()}`}
                     type="checkbox"
-                    checked={value.includes(option.value)}
+                    value={option.value}
+                    checked={value().includes(option.value)}
                     class={`rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${hasError() ? "text-red-900 " : "text-green-900"}`}
                   />
                   <label

--- a/packages/frontend/src/forms/UiForm.tsx
+++ b/packages/frontend/src/forms/UiForm.tsx
@@ -42,7 +42,7 @@ export function UiForm<
             {fieldSpec => {
               return (
                 <div>
-                  <Field name={fieldSpec.name}>
+                  <Field name={fieldSpec.name} type={fieldSpec.formType}>
                     {(field, props) => {
                       const spec = () => fieldSpec;
                       const error = () => field.error;

--- a/packages/frontend/src/forms/UiFormCheckboxField.tsx
+++ b/packages/frontend/src/forms/UiFormCheckboxField.tsx
@@ -7,6 +7,7 @@ export interface UiFormCheckboxFieldProps extends UiCheckboxFieldProps {
 }
 
 export default function UiFormCheckboxField(props: UiFormCheckboxFieldProps) {
+  console.log(props)
   const label = () => props.spec().label;
 
   const childProps = combineProps(

--- a/packages/frontend/src/forms/index.ts
+++ b/packages/frontend/src/forms/index.ts
@@ -1,3 +1,4 @@
+import type { FieldPathValue, FieldType } from "@modular-forms/solid";
 import {
   clearError,
   clearResponse,
@@ -5,16 +6,23 @@ import {
   FieldPath,
   FieldProps,
   FieldValues,
-  FormErrors,
   FormProps,
-  type MaybePromise,
   PartialKey,
   PartialValues,
   ResponseData,
   submit,
 } from "@modular-forms/solid";
 import { JSX } from "solid-js";
-import { type Static, type TSchema as TypeboxSchema } from "typebox";
+import {
+  IsArray,
+  IsBoolean,
+  IsNumber,
+  IsObject,
+  IsString,
+  type Static,
+  TProperties,
+  type TSchema as TypeboxSchema,
+} from "typebox";
 import typeboxForm from "./typeboxForm.js";
 
 type Form<TFieldValues extends FieldValues, TResponseData extends ResponseData> = (
@@ -29,7 +37,7 @@ type Field<TFieldValues extends FieldValues, TResponseData extends ResponseData>
 
 export type FieldSpec = {
   label: string;
-  type: "text" | "number" | "email" | "password" | "select" | "checkbox" | "radio" | "textarea";
+  type: "text" | "number" | "email" | "password" | "select" | "checkbox" | "radio" | "textarea" | "file";
   placeholder?: string;
   options?: () => { label: string; value: string }[];
   disabled?: boolean;
@@ -46,6 +54,7 @@ export type FieldSpecs<TFieldValues extends FieldValues> = {
 
 export type FormFieldSpec<TFieldValues extends FieldValues, TFieldPath extends FieldPath<TFieldValues>> = FieldSpec & {
   name: TFieldPath;
+  formType: FieldType<FieldPathValue<TFieldValues, TFieldPath>>;
 };
 
 export type FormSubmitHandler<TFieldValues extends FieldValues, TResponseData extends ResponseData = undefined> = (
@@ -64,6 +73,29 @@ export interface FormSpec<
   cancelForm: () => void;
 }
 
+const resolveFieldType = <TFieldValues extends FieldValues, TFieldName extends FieldPath<TFieldValues>>(
+  name: TFieldName,
+  property: TProperties[TFieldName],
+  spec: FieldSpec
+): FieldType<FieldPathValue<TFieldValues, TFieldName>> => {
+  if (IsString(property)) {
+    if (spec.type === "file") {
+      return "file" as FieldType<FieldPathValue<TFieldValues, TFieldName>>;
+    }
+    return "string" as FieldType<FieldPathValue<TFieldValues, TFieldName>>;
+  }
+  if (IsNumber(property)) {
+    return "number" as FieldType<FieldPathValue<TFieldValues, TFieldName>>;
+  }
+  if (IsBoolean(property)) {
+    return "boolean" as FieldType<FieldPathValue<TFieldValues, TFieldName>>;
+  }
+  if (IsArray(property)) {
+    return `${resolveFieldType(name, property.items, spec)}[]` as FieldType<FieldPathValue<TFieldValues, TFieldName>>;
+  }
+  throw new TypeError(`Schema doesn't contain a property with the name: ${name}`);
+};
+
 export function createFormSpec<
   TSchema extends TypeboxSchema,
   TFieldValues extends FieldValues = Static<TSchema>,
@@ -75,21 +107,29 @@ export function createFormSpec<
   order: TFieldName[] = Object.keys(specs) as TFieldName[],
   initialValues?: PartialValues<TFieldValues>
 ): FormSpec<TFieldValues, TResponseData, TFieldName> {
-  const validator = typeboxForm(schema)
   const [form, { Form, Field }] = createForm<TFieldValues, TResponseData>({
     initialValues,
-    validate: (values: PartialValues<TFieldValues>): MaybePromise<FormErrors<TFieldValues>> => {
-      const result = validator(values as any)
-      console.log(result)
-      return result as any;
-    },
+    validate: typeboxForm(schema),
   });
 
-  const fields = order.map(fieldName => {
-    const spec = specs[fieldName];
+  const getType = <TFieldPath extends FieldPath<TFieldValues>>(
+    name: TFieldPath
+  ): FieldType<FieldPathValue<TFieldValues, TFieldPath>> => {
+    if (IsObject(schema)) {
+      const spec = specs[name];
+      const property = schema.properties[name];
+      return resolveFieldType(name, property, spec);
+    }
+    throw new TypeError(`Schema doesn't contain a property with the name: ${name}`);
+  };
+
+  const fields = order.map(name => {
+    const spec = specs[name];
+    const formType = getType(name);
     return {
       ...spec,
-      name: fieldName,
+      name,
+      formType,
     };
   });
 


### PR DESCRIPTION
This PR fixes the form submission for dynamic forms. The problem occurred from missing the type annotation on the Field object (especially in case of array-backed fields like checkbox groups).